### PR TITLE
Add __pycache__ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .ipynb_checkpoints
+__pycache__


### PR DESCRIPTION
We've been importing from python modules and that generates __pychace__ at places which shouldn't be tracked.